### PR TITLE
Add comment parsers and tests

### DIFF
--- a/wright/src/grammar/parsers.rs
+++ b/wright/src/grammar/parsers.rs
@@ -3,3 +3,9 @@ pub mod literals;
 
 /// Wright expression parsers.
 pub mod expression;
+
+/// Wright comment and whitespace parsers.
+pub mod whitespace;
+
+/// Whitespace module tests
+mod whitespace_tests;

--- a/wright/src/grammar/parsers/whitespace.rs
+++ b/wright/src/grammar/parsers/whitespace.rs
@@ -1,0 +1,29 @@
+use crate::grammar::model::Fragment;
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::character::complete::{char, multispace0, not_line_ending};
+use nom::multi::{count, many0};
+use nom::sequence::{preceded, terminated};
+use nom::IResult;
+
+/// Parses a Wright single line comment
+pub fn line_comment(input: Fragment) -> IResult<Fragment, Fragment> {
+    preceded(
+        count(char('/'), 2),
+        not_line_ending,
+    )(input)
+}
+
+/// Parses a sequence of adjacent whitespace and comments
+/// Returns a vec containing the comment text lines
+pub fn token_delimiter(input: Fragment) -> IResult<Fragment, Vec<Fragment>> {
+    preceded(
+        multispace0,
+        many0(
+            terminated(
+                line_comment,
+                multispace0,
+            ),
+        ),
+    )(input)
+}

--- a/wright/src/grammar/parsers/whitespace_tests.rs
+++ b/wright/src/grammar/parsers/whitespace_tests.rs
@@ -13,8 +13,9 @@ fn single_comment() {
     let (f, h) = setup("// line comment");
     let frag = Fragment::new(&f, h);
     let res = whitespace::line_comment(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(val.source(), " line comment");
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -26,8 +27,9 @@ fn empty_comment() {
     let (f, h) = setup("//");
     let frag = Fragment::new(&f, h);
     let res = whitespace::line_comment(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(val.source(), "");
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -39,8 +41,9 @@ fn comment_with_tail() {
     let (f, h) = setup("// line comment\nnot a comment");
     let frag = Fragment::new(&f, h);
     let res = whitespace::line_comment(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 14);
+        assert_eq!(val.source(), " line comment");
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -52,8 +55,16 @@ fn comments_and_whitespace() {
     let (f, h) = setup("// line comment\n// this is another comment\n    // third comment\n");
     let frag = Fragment::new(&f, h);
     let res = whitespace::token_delimiter(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(
+            val.iter().map(Fragment::source).collect::<Vec<_>>(),
+            vec![
+                " line comment",
+                " this is another comment",
+                " third comment",
+            ],
+        );
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -65,8 +76,9 @@ fn empty() {
     let (f, h) = setup("");
     let frag = Fragment::new(&f, h);
     let res = whitespace::token_delimiter(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(val.len(), 0);
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -78,8 +90,14 @@ fn comment_only() {
     let (f, h) = setup("// comment");
     let frag = Fragment::new(&f, h);
     let res = whitespace::token_delimiter(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(
+            val.iter().map(Fragment::source).collect::<Vec<_>>(),
+            vec![
+                " comment",
+            ],
+        );
     } else {
         eprintln!("{:#?}", res);
         assert!(false);
@@ -91,8 +109,9 @@ fn whitespace_only() {
     let (f, h) = setup("\t  \n\n   \t  ");
     let frag = Fragment::new(&f, h);
     let res = whitespace::token_delimiter(frag);
-    if let Ok((rem, _)) = res {
+    if let Ok((rem, val)) = res {
         assert_eq!(rem.len(), 0);
+        assert_eq!(val.len(), 0);
     } else {
         eprintln!("{:#?}", res);
         assert!(false);

--- a/wright/src/grammar/parsers/whitespace_tests.rs
+++ b/wright/src/grammar/parsers/whitespace_tests.rs
@@ -22,6 +22,32 @@ fn single_comment() {
 }
 
 #[test]
+fn empty_comment() {
+    let (f, h) = setup("//");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::line_comment(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
+fn comment_with_tail() {
+    let (f, h) = setup("// line comment\nnot a comment");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::line_comment(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 14);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
 fn comments_and_whitespace() {
     let (f, h) = setup("// line comment\n// this is another comment\n    // third comment\n");
     let frag = Fragment::new(&f, h);

--- a/wright/src/grammar/parsers/whitespace_tests.rs
+++ b/wright/src/grammar/parsers/whitespace_tests.rs
@@ -1,0 +1,74 @@
+use crate::grammar::model::Fragment;
+use crate::grammar::parsers::whitespace;
+use codespan::{FileId, Files};
+
+fn setup(src: &str) -> (Files<String>, FileId) {
+    let mut f: Files<String> = Files::new();
+    let id = f.add("test", src.to_string());
+    (f, id)
+}
+
+#[test]
+fn single_comment() {
+    let (f, h) = setup("// line comment");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::line_comment(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
+fn comments_and_whitespace() {
+    let (f, h) = setup("// line comment\n// this is another comment\n    // third comment\n");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::token_delimiter(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
+fn empty() {
+    let (f, h) = setup("");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::token_delimiter(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
+fn comment_only() {
+    let (f, h) = setup("// comment");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::token_delimiter(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}
+
+#[test]
+fn whitespace_only() {
+    let (f, h) = setup("\t  \n\n   \t  ");
+    let frag = Fragment::new(&f, h);
+    let res = whitespace::token_delimiter(frag);
+    if let Ok((rem, _)) = res {
+        assert_eq!(rem.len(), 0);
+    } else {
+        eprintln!("{:#?}", res);
+        assert!(false);
+    }
+}


### PR DESCRIPTION
Adds a line comment parser for `//` comments and a token delimiter parser that parses a (possibly empty) sequence of comments and whitespace